### PR TITLE
Changed srcparam1 and srcparam2 to be float array's by default

### DIFF
--- a/mesh2blender.py
+++ b/mesh2blender.py
@@ -61,12 +61,12 @@ class mesh2scene(bpy.types.Operator):
         dg = bpy.context.evaluated_depsgraph_get()
         dg.update()
 
-        ## add cfg option
+        # add cfg option
         obj = bpy.data.objects['source']
         obj["nphoton"] = 10000
-        obj["srctype"]="pencil"
-        obj["srcparam1"]=[0,0,0,0]
-        obj["srcparam2"]=[0,0,0,0]
+        obj["srctype"] = "pencil"
+        obj["srcparam1"] = [0.0, 0.0, 0.0, 0]
+        obj["srcparam2"] = [0.0, 0.0, 0.0, 0]
         obj["unitinmm"] = 1.0
 
     def execute(self, context):

--- a/mesh2blender.py
+++ b/mesh2blender.py
@@ -65,8 +65,8 @@ class mesh2scene(bpy.types.Operator):
         obj = bpy.data.objects['source']
         obj["nphoton"] = 10000
         obj["srctype"] = "pencil"
-        obj["srcparam1"] = [0.0, 0.0, 0.0, 0]
-        obj["srcparam2"] = [0.0, 0.0, 0.0, 0]
+        obj["srcparam1"] = [0.0, 0.0, 0.0, 0.0]
+        obj["srcparam2"] = [0.0, 0.0, 0.0, 0.0]
         obj["unitinmm"] = 1.0
 
     def execute(self, context):


### PR DESCRIPTION
Changing the srcparams from integers to floats was annoying by hand. So this is a patch that defaults to srcparams being float arrays.
I've checked the src of MMC and it appears they are treated as floats, so I don't think this should break anything.